### PR TITLE
update alwayshp.js to fix window locked to left side of screen

### DIFF
--- a/alwayshp.js
+++ b/alwayshp.js
@@ -53,7 +53,7 @@ export class AlwaysHP extends HandlebarsApplicationMixin(ApplicationV2) {
             },
             position: {
                 top: pos?.top || 60,
-                left: pos?.left || (($('#board').width / 2) - 150),
+                left: pos?.left || ($('#board').width() / 2 - 150),
                 width: 300
             }
         }


### PR DESCRIPTION
fixes an issue where the window is locked to the left side of the screen